### PR TITLE
Update setup-lando to v3

### DIFF
--- a/.github/workflows/pr-mariadb-tests.yml
+++ b/.github/workflows/pr-mariadb-tests.yml
@@ -53,7 +53,7 @@ jobs:
           version: dev
           sync: false
       - name: Setup lando ${{ matrix.lando-version }}
-        uses: lando/setup-lando@v2
+        uses: lando/setup-lando@v3
         with:
           lando-version: ${{ matrix.lando-version }}
           config: |


### PR DESCRIPTION
v2 no longer works since Github removed docker-compose from their images last week